### PR TITLE
Update hdri-names.json

### DIFF
--- a/humans/input-jsons/hdri-names.json
+++ b/humans/input-jsons/hdri-names.json
@@ -19,27 +19,7 @@
             ]
           }
         }
-      },
-      "camera_and_light_rigs": [
-        {
-          "cameras": [
-            {
-              "specifications": {
-                "resolution_w": 512,
-                "resolution_h": 512
-              }
-            }
-          ],
-          "location": {
-            "z": {
-              "type": "list",
-              "values": [
-                1
-              ]
-            }
-          }
-        }
-      ]
+      }
     }
   ]
 }


### PR DESCRIPTION
No need to have the camera settings to get the image that is currently on the doc page. The image is created using the default camera settings